### PR TITLE
Lock configuration to prevent change in camera resolution

### DIFF
--- a/CameraController/Views/CameraPreviewInternal.swift
+++ b/CameraController/Views/CameraPreviewInternal.swift
@@ -24,7 +24,15 @@ class CameraPreviewInternal: NSView {
 
         configureDevice(device)
         setupPreviewLayer(captureSession)
-        captureSession.startRunning()
+        // lock configuration to keep device.activeFormat
+        do {
+            try captureDevice?.lockForConfiguration()
+            captureSession.startRunning()
+            captureDevice?.unlockForConfiguration()
+        } catch {
+            // Handle error.
+        }
+        
     }
 
     private func setupPreviewLayer(_ captureSession: AVCaptureSession) {
@@ -53,7 +61,14 @@ class CameraPreviewInternal: NSView {
         if captureDevice != cam {
             captureSession.stopRunning()
             configureDevice(cam)
-            captureSession.startRunning()
+            // lock configuration to keep device.activeFormat
+            do {
+                try captureDevice?.lockForConfiguration()
+                captureSession.startRunning()
+                captureDevice?.unlockForConfiguration()
+            } catch {
+                // Handle error.
+            }
         }
     }
 


### PR DESCRIPTION
Before this change, changes of the camera resolution in another program would be overridden every time a camera is selected here.