### PR TITLE
Update Hombrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Download the latest `.zip` from [Releases](https://github.com/itaybre/CameraCont
 ### Homebrew
 
 ```
-brew tap homebrew/cask-drivers
 brew install --cask cameracontroller
 ```
 


### PR DESCRIPTION
The repository https://github.com/Homebrew/homebrew-cask-drivers has been deprecated and is empty. As this cask is now moved to the default homebrew repository, tapping it is no longer necessary.