### PR TITLE
README Fix: removes homebrew cask drivers tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Download the latest `.zip` from [Releases](https://github.com/itaybre/CameraCont
 ### Homebrew
 
 ```
-brew tap homebrew/cask-drivers
 brew install --cask cameracontroller
 ```
 


### PR DESCRIPTION
Fixes this homebrew deprecation:

```
❯ brew tap homebrew/cask-drivers

Error: homebrew/cask-drivers was deprecated. 
This tap is now empty and all its contents were 
either deleted or migrated.
```

<img width="783" alt="image" src="https://github.com/Itaybre/CameraController/assets/637225/33d42c6d-6335-409e-999b-323450012383">
